### PR TITLE
Checking whether NOVA fs can be checkpointed

### DIFF
--- a/fs_bugs/nova/checkpoint_experiment/Makefile
+++ b/fs_bugs/nova/checkpoint_experiment/Makefile
@@ -1,0 +1,22 @@
+CC=gcc
+UTILITY_DIR := ../../test_utilities
+UTILITY_SRC := $(wildcard $(UTILITY_DIR)/*.c)
+UTILITY_OBJ := $(patsubst $(UTILITY_DIR)/%,%.o,$(UTILITY_SRC))
+
+override CFLAGS += -g -I../../test_utilities -I../../../fs-state -I../../../include
+override LIBS += -lssl -lcrypto -lrt -lpthread -lz
+
+driver: driver.c utility-libs
+	$(CC) -o driver driver.c utility-libs.a $(CFLAGS) $(LIBS)
+
+test: driver
+	sudo bash -x run_driver.sh
+
+utility-libs: $(UTILITY_OBJ)
+	ar rvs $@.a $^
+
+%.c.o: $(UTILITY_DIR)/%.c
+	gcc -Wall -Werror -o $@ -fPIC -c $< $(CFLAGS) $(LIBS)
+
+clean:
+	rm -f *.o *.a driver ckpt_tmp.img

--- a/fs_bugs/nova/checkpoint_experiment/driver.c
+++ b/fs_bugs/nova/checkpoint_experiment/driver.c
@@ -1,0 +1,138 @@
+#include "mounts.h"
+#include "fileutil.h"
+#include "fstestutil.h"
+#include "stdlib.h"
+
+void do_checkpoint(const char *devpath, char **bufptr)
+{
+	int devfd = open(devpath, O_RDWR);
+	assert(devfd >= 0);
+	size_t fs_size = fsize(devfd);
+	char *buffer, *ptr;
+	// size_t remaining = fs_size;
+	// const size_t bs = 4096;
+
+	ptr = mmap(NULL, fs_size, PROT_READ | PROT_WRITE, MAP_SHARED, devfd, 0);
+	assert(ptr != MAP_FAILED);
+	buffer = malloc(fs_size);
+	assert(buffer);
+
+	memcpy(buffer, ptr, fs_size);
+	*bufptr = buffer;
+
+	munmap(ptr, fs_size);
+	close(devfd);
+}
+
+void do_restore(const char *devpath, char *buffer)
+{
+	int devfd = open(devpath, O_RDWR);
+	assert(devfd >= 0);
+	size_t size = fsize(devfd);
+	char *ptr;
+
+	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, devfd, 0);
+	assert(ptr != MAP_FAILED);
+	
+	memcpy(ptr, buffer, size);
+    free(buffer);
+
+	munmap(ptr, size);
+	close(devfd);
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <mountpoint>\n", argv[0]);
+        exit(1);
+    }
+    char *mp = NULL;
+    char *char_dev = "/dev/pmem0", *blk_dev = "/dev/pmem0", *fs_type = "nova";
+
+    mp = argv[1];
+
+    char cmdbuf[PATH_MAX];
+    char lscmdbuf[PATH_MAX];
+    // Set up test file and directory pathname
+    char test_file[PATH_MAX] = {0};
+    char test_dir[PATH_MAX] = {0};
+    snprintf(test_file, PATH_MAX, "%s/test.txt", mp);
+    snprintf(test_dir, PATH_MAX, "%s/testdir", mp);
+
+    bool is_changed = false;
+    int ret = -1;
+    crc32_state_t curr_hash, prev_hash;
+    int ops_num = -1;
+
+    snprintf(lscmdbuf, PATH_MAX, "ls -lrt %s", mp);
+    fprintf(stdout, "Contents of %s before FS creation\n", mp);
+    execute_cmd(lscmdbuf);
+
+
+
+
+    snprintf(cmdbuf, PATH_MAX, "mount -t NOVA -o init %s %s", char_dev, mp);
+    execute_cmd(cmdbuf);
+    fprintf(stdout, "Mounted NOVA file system on %s \n", mp);
+
+
+    //Create 2 files, and a directory 
+    ops_num = 4;
+    ret = randSyscallChanger(ops_num, test_file, test_dir, &is_changed);
+    ops_num=0;
+
+    ret = randSyscallChanger(ops_num, test_file, test_dir, &is_changed);
+    snprintf(test_file, PATH_MAX, "%s/test2.txt", mp);
+    ret = randSyscallChanger(ops_num, test_file, test_dir, &is_changed);
+
+
+    fprintf(stdout, "Contents of %s before unmount\n", mp);
+    execute_cmd(lscmdbuf);
+
+    fprintf(stdout, "Unmounting NOVA after creating files\n");
+    unmount_fs(mp, fs_type);
+
+
+    fprintf(stdout, "Contents of %s after unmount\n", mp);
+    execute_cmd(lscmdbuf);
+
+    char** buffptr = (char**) calloc(1, sizeof(char *));
+    do_checkpoint(char_dev, buffptr);
+    
+    
+    
+    fprintf(stdout, "Checkpointing done\n");
+
+
+    //Mount the fs again without init option
+    snprintf(cmdbuf, PATH_MAX, "mount -t NOVA %s %s", char_dev, mp);
+    fprintf(stdout, "Mounting fs again to change files\n");
+    execute_cmd(cmdbuf);
+    //Create new file, and delete test2.txt
+    ops_num=3; 
+    ret = randSyscallChanger(ops_num, test_file, test_dir, &is_changed);
+    ops_num=0;
+    snprintf(test_file, PATH_MAX, "%s/test3.txt", mp);    
+    ret = randSyscallChanger(ops_num, test_file, test_dir, &is_changed);
+
+    fprintf(stdout, "Contents of %s after changing files\n", mp);
+    execute_cmd(lscmdbuf);
+
+    fprintf(stdout, "Files changed, Unmounting NOVA\n");
+
+
+
+
+    unmount_fs(mp, fs_type);
+    do_restore(char_dev, *buffptr);
+    fprintf(stdout, "Restore done\n");
+    //Mount the fs again
+    execute_cmd(cmdbuf);
+
+    fprintf(stdout, "Nova mounted after restore\n");    
+    fprintf(stdout, "Contents of %s after mounting again\n", mp);
+    execute_cmd(lscmdbuf);
+    return 0;
+}
+

--- a/fs_bugs/nova/checkpoint_experiment/run_driver.sh
+++ b/fs_bugs/nova/checkpoint_experiment/run_driver.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#DRIVER_LOOP_MAX=100000
+
+# NOVA parameters
+#JFFS2_SIZE=262144
+NOVA_MNT_DIR="/mnt/ramdisk"
+MTDBLK_DEVICE="/dev/pmem0"
+
+# Set up NOVA
+setup_nova() {
+    #modprobe mtd
+    #modprobe mtdram total_size=$(expr $JFFS2_SIZE / 1024) erase_size=16
+    #modprobe mtdblock
+       
+
+    #Check if NOVA is mounted already, if yes unmount it
+    if test -n "$(mount | grep $NOVA_MNT_DIR)" ; then
+        umount $NOVA_MNT_DIR || exit $?
+    fi
+
+
+    #Remove mount point if not created, and create it again
+    if test -d $NOVA_MNT_DIR ; then
+        rm -rf $NOVA_MNT_DIR
+    fi
+    mkdir -p $NOVA_MNT_DIR
+
+    modprobe nova
+    #https://github.com/NVSL/linux-nova/blob/master/Documentation/filesystems/nova.txt (Steps for setting up NOVA)
+}
+
+# Run driver
+setup_nova
+
+# Usage: ./driver mountpoint
+./driver $NOVA_MNT_DIR 
+

--- a/fs_bugs/test_utilities/fstestutil.c
+++ b/fs_bugs/test_utilities/fstestutil.c
@@ -13,7 +13,7 @@ int randSyscall(int ops_num, char *test_file, char *test_dir)
             writelen = getRandNum(0, 64409);
             writebyte = getRandNum(1, 255);
             char *data = malloc(writelen);
-            generate_data(data, writelen, writebyte);
+            generate_test_data(data, writelen, writebyte);
             ret = write_file(test_file, O_RDWR, data, (off_t)offset, (size_t)writelen);
             free(data);
             break;
@@ -53,7 +53,7 @@ int randSyscallChanger(int ops_num, char *test_file, char *test_dir, bool *chang
             writelen = getRandNum(0, 64409);
             writebyte = getRandNum(1, 255);
             char *data = malloc(writelen);
-            generate_data(data, writelen, writebyte);
+            generate_test_data(data, writelen, writebyte);
             ret = write_file(test_file, O_RDWR, data, (off_t)offset, (size_t)writelen);
             free(data);
             if (ret > 0)

--- a/fs_bugs/test_utilities/fstestutil.h
+++ b/fs_bugs/test_utilities/fstestutil.h
@@ -29,7 +29,7 @@
 #define BUF_SIZE 4096
 typedef unsigned char crc32_state_t[4];
 
-static inline void generate_data(char *buffer, size_t len, int value)
+static inline void generate_test_data(char *buffer, size_t len, int value)
 {
     if (value > 0) {
         memset(buffer, value, len);


### PR DESCRIPTION
I had to rename generate_data in fs_testutil.h to some other generate_test_data since its signature was colliding with fileutils.h which i needed to include for checkpointing and getting fsize.

Image showing the FS contents at mount point:
![image](https://user-images.githubusercontent.com/47530525/232334871-20451ae3-e012-470f-a88d-f30ed93a502a.png)


1- Initial period
2- After unmounting, checkpoint and remount
3- After unmount again and restore